### PR TITLE
Add petrelharp as recipe maintainer

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,4 @@ extra:
   recipe-maintainers:
     - jeromekelleher
     - benjeffery
+    - petrelharp


### PR DESCRIPTION
## Summary
- Add petrelharp as a recipe maintainer for msprime-feedstock

This PR adds petrelharp to the list of recipe maintainers for the msprime conda-forge package.