### PR TITLE
Add petrelharp as recipe maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @benjeffery @jeromekelleher
+* @benjeffery @jeromekelleher @petrelharp

--- a/README.md
+++ b/README.md
@@ -373,4 +373,5 @@ Feedstock Maintainers
 
 * [@benjeffery](https://github.com/benjeffery/)
 * [@jeromekelleher](https://github.com/jeromekelleher/)
+* [@petrelharp](https://github.com/petrelharp/)
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -66,3 +66,4 @@ extra:
   recipe-maintainers:
     - jeromekelleher
     - benjeffery
+    - petrelharp


### PR DESCRIPTION
## Summary
- Add petrelharp as a recipe maintainer for msprime-feedstock

This PR adds petrelharp to the list of recipe maintainers for the msprime conda-forge package.